### PR TITLE
Remove `window.MinecraftSkinViewer = MinecraftSkinViewer` for the compatibility of next.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -207,6 +207,4 @@ class MinecraftSkinViewer {
     }
 }
 
-window.MinecraftSkinViewer = MinecraftSkinViewer;
-
 export default MinecraftSkinViewer


### PR DESCRIPTION
I'm getting the error thrown by next.js: `Cannot assign to read only property 'params' of object '#<Object>'`

And after a long time of debugging, I found the source of this error is at:
https://github.com/MinecraftCapes/minecraft-skin-viewer/blob/c0c1004ec2211121da9ccb9711c882385722f6a7/src/main.js#L210

This line used the `window` object to expose the `MinecraftSkinViewer` class, but in next.js, this line would trigger something unexpected under the server environment during the SSR process. For the detailed information, see https://github.com/vercel/next.js/discussions/84512

This PR can solve the issue, but may not be the best solution. If you have better ideas, feel free to let me know. Thanks.