### PR TITLE
Fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "typings": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/minecraft-skin-viewer.js",
       "require": "./dist/minecraft-skin-viewer.umd.cjs"
     }


### PR DESCRIPTION
Despite TSPlayground working the types were still borked technically.
https://tsplay.dev/mLeAKW 

Should be good now
```
feat/types ✔ $ npx --yes @arethetypeswrong/cli --pack .         

minecraft-skin-viewer v0.0.15

Build tools:
- vite@^7.3.1

👺 Import resolved to an ESM type declaration file, but a CommonJS JavaScript file. https://github.com/arethetypeswrong/are
thetypeswrong.github.io/blob/main/docs/problems/FalseESM.md


┌───────────────────┬─────────────────────────┐
│                   │ "minecraft-skin-viewer" │
├───────────────────┼─────────────────────────┤
│ node10            │ 🟢                      │
├───────────────────┼─────────────────────────┤
│ node16 (from CJS) │ 👺 Masquerading as ESM  │
├───────────────────┼─────────────────────────┤
│ node16 (from ESM) │ 🟢 (ESM)                │
├───────────────────┼─────────────────────────┤
│ bundler           │ 🟢                      │
└───────────────────┴─────────────────────────┘
```